### PR TITLE
address log transform errors in plotConcPred, plotFluxPred, and boxConcThree

### DIFF
--- a/R/convertToEGRET.R
+++ b/R/convertToEGRET.R
@@ -80,7 +80,7 @@ convertToEGRETSample <- function(intdat, meta, qconvert = 35.314667, dailydat = 
   if(!is.null(dailydat)){
     subDaily <- select(sample_df, dateTime) %>%
       left_join(select(dailydat, dateTime, SE, yHat), by="dateTime") %>%
-      mutate(ConcHat = yHat*exp((SE^2)/2)) 
+      mutate(ConcHat = exp(yHat)*exp((SE^2)/2)) 
     
     sample_df <- bind_cols(sample_df, subDaily)
   }


### PR DESCRIPTION
See #99, #100.

@ldecicco-USGS I put this on Slack, but I'll do a more formal review request here. Is the assumption that `yHat` needs to be unlogged when used to calculate `ConcHat` correct? When I did that, it appeared to make reasonable plots.

Before/Afters for `plotEGRET("boxConcThree" , intdat, estdat, preds, meta)`:
![image](https://cloud.githubusercontent.com/assets/13220910/22085866/9a0a8484-dd9b-11e6-923c-0994d640b3a8.png)


Before/Afters for `plotEGRET("plotConcPred" , intdat, estdat, preds, meta)`:
![image](https://cloud.githubusercontent.com/assets/13220910/22085824/637c4d30-dd9b-11e6-8694-d547e8cffe4f.png)

Before/Afters for `plotEGRET("plotFluxPred" , intdat, estdat, preds, meta)`:
![image](https://cloud.githubusercontent.com/assets/13220910/22085845/84f54854-dd9b-11e6-9028-62eaa661899c.png)
