### PR TITLE
rm "WRTDS" from default title in fluxBiasMulti

### DIFF
--- a/R/plotEGRET.R
+++ b/R/plotEGRET.R
@@ -150,7 +150,7 @@ plotEGRET <- function(plot.name, intdat = NULL, estdat = NULL, preds = NULL,
          boxConcThree = boxConcThree(egretobj, ...), 
          plotConcHist = plotConcHist(egretobj, ...), 
          plotFluxHist = plotFluxHist(egretobj, ...),
-         fluxBiasMulti = fluxBiasMulti(egretobj, ...),
+         fluxBiasMulti = fluxBiasMulti(egretobj, moreTitle = NULL, ...),
          
          # default if no name matches
          stop(paste('unrecognized plot.name:', plot.name)))


### PR DESCRIPTION
Addressing #141. 

There is an argument to `EGRET::fluxBiasMulti` called `moreTitle` that defaults to "WRTDS". I made the default in `loadflex::plotEGRET` `NULL`.