### PR TITLE
Bias corrections (loadComp + loadInterp)

### DIFF
--- a/R/loadComp.R
+++ b/R/loadComp.R
@@ -293,27 +293,29 @@ predictSolute.loadComp <- function(
       # The mean: always use se.pred (rather than se.fit) to calculate the mean in
       # log space.
       preds_log <- mixedToLog(meanlin=predvec_lin, sdlog=se_log)
-      preds_lin <- logToLin(mslist=preds_log)
-      
-      # The intervals:
-      if(interval == "prediction") {
-        # degrees of freedom are not straightforward for the interpolation part of
-        # the model, so use qnorm instead of qt to get quantiles.
-        ci_quantiles <- qnorm(p=0.5+c(-1,1)*level/2)
-        preds_lin$lwr <- exp(preds_log$meanlog + ci_quantiles[1]*se_log) 
-        preds_lin$upr <- exp(preds_log$meanlog + ci_quantiles[2]*se_log)
-      }
-      # The SEs:
-      if(se.pred) {
-        preds_lin$se.pred <- preds_lin$sdlin
-      }
       
       if(log.or.lin == "log"){
         preds <- preds_log
       } else {
+        
+        preds_lin <- logToLin(mslist=preds_log)
+        
+        # The intervals:
+        if(interval == "prediction") {
+          # degrees of freedom are not straightforward for the interpolation part of
+          # the model, so use qnorm instead of qt to get quantiles.
+          ci_quantiles <- qnorm(p=0.5+c(-1,1)*level/2)
+          preds_lin$lwr <- exp(preds_log$meanlog + ci_quantiles[1]*se_log) 
+          preds_lin$upr <- exp(preds_log$meanlog + ci_quantiles[2]*se_log)
+        }
+        # The SEs:
+        if(se.pred) {
+          preds_lin$se.pred <- preds_lin$sdlin
+        }
+        
         preds <- preds_lin
       }
-      
+
     } else {
       
       #\\# TO DO: NEED TO CONVERT LIN TO LOG IF log.or.lin == "linear" #\\#

--- a/R/loadComp.R
+++ b/R/loadComp.R
@@ -346,6 +346,8 @@ predictSolute.loadComp <- function(
     # Format the output
     preds_lin$sdlin <- NULL # we've copied this to the se.pred column if we wanted it
     names(preds_lin)[1] <- "fit" # name consistently with other predictSolute outputs
+    
+    preds <- preds_lin
   } else {
     # If we're not returning any uncertainty info, format as a vector rather than as a data.frame
     preds <- predvec
@@ -353,7 +355,7 @@ predictSolute.loadComp <- function(
   
   # Add dates if requested
   if(date) {
-    if(!is.data.frame(preds_lin)) {
+    if(!is.data.frame(preds)) {
       preds <- data.frame(fit=preds)
     }
     # prepend the date column

--- a/R/loadComp.R
+++ b/R/loadComp.R
@@ -292,6 +292,9 @@ predictSolute.loadComp <- function(
       se_log <- sqrt(load.model@MSE["mean", 1]) 
       # The mean: always use se.pred (rather than se.fit) to calculate the mean in
       # log space.
+      
+      ## if model was in log space and user requested log, then preds should
+      ## just be equal to predvec. Would we need to do this?
       preds_log <- mixedToLog(meanlin=predvec_lin, sdlog=se_log)
       
       if(log.or.lin == "log"){

--- a/R/loadComp.R
+++ b/R/loadComp.R
@@ -297,7 +297,7 @@ predictSolute.loadComp <- function(
       ## just be equal to predvec. Would we need to do this?
       preds_log <- mixedToLog(meanlin=predvec_lin, sdlog=se_log)
       
-      if(log.or.lin == "log"){
+      if(lin.or.log == "log"){
         preds <- preds_log
       } else {
         

--- a/R/loadInterp.R
+++ b/R/loadInterp.R
@@ -242,6 +242,10 @@ predictSolute.loadInterp <- function(
   meta <- load.model@metadata
   fit <- load.model@fit
   
+  if(lin.or.log == "log"){
+    stop("loadInterp model is not currently setup to handle log space predictions")
+  }
+  
   # Use fitting data if newdata are not supplied
   if(missing(newdata)) {
     newdata <- getFittingData(load.model)

--- a/R/loadInterp.R
+++ b/R/loadInterp.R
@@ -242,10 +242,6 @@ predictSolute.loadInterp <- function(
   meta <- load.model@metadata
   fit <- load.model@fit
   
-  if(lin.or.log == "log"){
-    stop("loadInterp model is not currently setup to handle log space predictions")
-  }
-  
   # Use fitting data if newdata are not supplied
   if(missing(newdata)) {
     newdata <- getFittingData(load.model)
@@ -319,7 +315,13 @@ predictSolute.loadInterp <- function(
     preds <- data.frame(date=getCol(load.model@metadata, newdata, "date"), preds)
   }
   
-  preds
+  if(lin.or.log == "log"){
+    preds$fit <- log(preds$fit)
+    preds$se.fit <- NA
+    preds$se.preds <- NA
+  }
+  
+  return(preds)
 }
 
 # Of the required loadModelInterface functions, getMetadata, getFittingData, and


### PR DESCRIPTION
Still have some "to-dos" written into the code, but it's coming along.

We determined that `loadInterp` would not need to handle any bias corrections because it already does calculations in linear space. There is not a way for users to model in log space, but should users still be able to return log predictions from the linear calculation? For now, I put in a stop for `log.or.lin == "log"`.

`loadComp` has a model-specified linear or log space pattern (`load.model@fit@log.resids`) in addition to this user-specified argument about returning log or linear predictions (`log.or.lin`). This makes things a bit trickier. `predvec` is now log or linear depending on `lin.or.log`.

Possible scenarios in `predictSolute.loadComp`: 

- [ ] 1. uncertainty is requested & model was log space & user requested log
- [x] 2. uncertainty is requested & model was log space & user requested linear
- [ ] 3. uncertainty is requested & model was linear space & user requested log
- [x] 4. uncertainty is requested & model was linear space & user requested linear
- [ ] 5. uncertainty NOT requested & model was log space & user requested log
- [ ] 6. uncertainty NOT requested & model was log space & user requested linear
- [ ] 7. uncertainty NOT requested & model was linear space & user requested log
- [ ] 8. uncertainty NOT requested & model was linear space & user requested linear
