### PR TITLE
keep aggregateSolute output minimal (remove bonus columns)

### DIFF
--- a/man/aggregateSolute.Rd
+++ b/man/aggregateSolute.Rd
@@ -10,8 +10,7 @@ aggregateSolute(preds, metadata, format = c("conc", "flux rate",
   "[custom]"), se.preds, dates, custom = NA,
   cormat.function = cormat1DayBand, ci.agg = TRUE, level = 0.95,
   deg.free = NA, ci.distrib = c("lognormal", "normal"), se.agg = TRUE,
-  na.rm = FALSE, attach.units = FALSE, complete.threshold = 0,
-  model.name = NA)
+  na.rm = FALSE, attach.units = FALSE, complete.threshold = 0)
 }
 \arguments{
 \item{preds}{Either a vector of predicted instantaneous fluxes or 
@@ -79,9 +78,6 @@ of the second column of the returned data.frame.}
 
 \item{complete.threshold}{numeric number of observations below which an \code{agg.by}
 value, e.g. a year, will be considered incomplete and be discarded}
-
-\item{model.name}{char Name of the model that generated the predictions.
-Returned with each row of the output data.frame}
 }
 \value{
 A data.frame with two columns. The first contains the aggregation 


### PR DESCRIPTION
@wdwatkins - loadflex follows an opposite philosophy from EGRET, which tries to make all the details available in every dataset so what you need is always right there. In contrast, loadflex tries to make data.frames as small as possible, with the idea that this can save storage space, make version control diffs more informative, and avoid data corruption by reducing redundancy. It's a matter of opinion, and I don't think there's a right answer. But i'm sticking with mine for loadflex, hence this PR:

I've taken out the `model.name` argument and removed the `site.id`, `mode`l, and `constituent` columns from the output of `aggregateSolute`. I've replaced them on the batch.R side in the loadflexBatch PR I'm about to submit. 

I know you just added these features to `aggregateSolute`, so I wanted to explain why I was moving them from loadflex to loadflexBatch. Your work is not unappreciated, just relocated.