### PR TITLE
actually keep all modifiable metadata in loadReg2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: loadflex
 Type: Package
 Title: Models and Tools for Watershed Flux Estimates
-Version: 1.1.9
-Date: 2017-03-19
+Version: 1.1.10
+Date: 2017-03-31
 Authors@R: c(
     person("Alison P.", "Appling", , "aappling@usgs.gov", c("aut", "cre")),
     person("Miguel C.", "Leon", , , "aut"),

--- a/R/loadReg2.R
+++ b/R/loadReg2.R
@@ -86,7 +86,7 @@ loadReg2 <- function(
   consti.name="", load.rate="", 
   site.id="", lat=as.numeric(NA), lon=as.numeric(NA), basin.area=as.numeric(NA),
   flow.site.name="", flow.site.id="", flow.lat=as.numeric(NA), flow.lon=as.numeric(NA), flow.basin.area=as.numeric(NA),
-  basin.area.units="km^2", custom,                     
+  basin.area.units="km^2", custom=NULL,                     
   ...) {
   
   # Validate arguments
@@ -154,8 +154,13 @@ loadReg2 <- function(
   
   # Get the metadata, which we'll need to do the following data checks
   meta <- getMetadata(load.reg)
-  # Fill the site.id field if given in args, since rloadest only has a site.name equivalent
-  meta <- updateMetadata(meta, site.id = site.id)
+  # Fill the metadata fields not fixed by the rloadest loadReg object
+  meta <- updateMetadata(
+    meta, 
+    consti.name=consti.name, load.rate=load.rate, 
+    site.id=site.id, lat=lat, lon=lon, basin.area=basin.area,
+    flow.site.name=flow.site.name, flow.site.id=flow.site.id, flow.lat=flow.lat, flow.lon=flow.lon, flow.basin.area=flow.basin.area,
+    basin.area.units=basin.area.units, custom=custom)
   
   # Parse the loadReg call, attaching argument names as needed. This will be
   # useful both for the refitting function and for saving the original data.

--- a/man/loadReg2.Rd
+++ b/man/loadReg2.Rd
@@ -9,7 +9,7 @@ loadReg2(load.reg, pred.format = c("flux", "conc"), store = c("data",
   lat = as.numeric(NA), lon = as.numeric(NA), basin.area = as.numeric(NA),
   flow.site.name = "", flow.site.id = "", flow.lat = as.numeric(NA),
   flow.lon = as.numeric(NA), flow.basin.area = as.numeric(NA),
-  basin.area.units = "km^2", custom, ...)
+  basin.area.units = "km^2", custom = NULL, ...)
 }
 \arguments{
 \item{load.reg}{An unevaluated call to \code{\link[rloadest]{loadReg}}. This 


### PR DESCRIPTION
part of this task was already implemented, but it needed another step of actually saving the modifiable metadata that a user passed into a loadReg2 object, along with the metadata that gets shared by the loadReg and loadReg2 objects.